### PR TITLE
Address issues exposed by changes in default settings of GCC 10.x and later

### DIFF
--- a/lib/fmm/src/mp_wrapper.f90
+++ b/lib/fmm/src/mp_wrapper.f90
@@ -491,7 +491,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
-	
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    integer(kind=8)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 		elem_tmp = 1
 		
 		call mpi_allreduce(MPI_IN_PLACE,dst,elem_tmp,MPI_INTEGER8,op,comm,ierr)
@@ -510,6 +515,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    integer(kind=8), dimension(*) :: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -528,6 +539,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = 1
 		
@@ -547,6 +564,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -566,6 +589,12 @@ implicit none
         integer(MyMPI_Comm)             :: comm
         integer(MyMPI_Errorcode)        :: ierr,ierr2
         integer(MyMPI_Entries)          :: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
         
                 lo = lbound(dst,1)
                 hi = ubound(dst,1)
@@ -586,6 +615,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8)		:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = 1
 		
@@ -605,6 +640,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		elem_tmp = elem
 		
@@ -624,6 +665,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allreduce(send,recv,num,rtype,rop,rcomm,rerr)
+	    real(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, num, rop, rtype, rcomm, rerr
+	  end subroutine mpi_allreduce
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)
@@ -648,6 +695,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    byte, dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)	
@@ -668,6 +721,12 @@ implicit none
 	integer(MyMPI_Comm) 	:: comm
 	integer(MyMPI_Errorcode):: ierr,ierr2
 	integer(MyMPI_Entries)	:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    byte, dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo1 = lbound(dst,1)
 		hi1 = ubound(dst,1)
@@ -690,6 +749,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    real(kind=4), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		elem_tmp = elem
 		
@@ -708,6 +773,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    integer(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		elem_tmp = elem
 		
@@ -726,6 +797,12 @@ implicit none
 	integer(MyMPI_Comm) 		:: comm
 	integer(MyMPI_Errorcode)	:: ierr,ierr2
 	integer(MyMPI_Entries)		:: elem_tmp
+	interface
+	  subroutine mpi_allgather(send,snum,stype,recv,rnum,rtype,gcomm,gerr)
+	    integer(kind=8), dimension(*)	:: recv
+	    integer(kind=4)		:: send, snum, rnum, stype, rtype, gcomm, gerr
+	  end subroutine mpi_allgather
+	end interface
 	
 		lo = lbound(dst,1)
 		hi = ubound(dst,1)	

--- a/src/fcs_fmm.c
+++ b/src/fcs_fmm.c
@@ -430,7 +430,7 @@ FCSResult fcs_fmm_tune(FCS handle, fcs_int local_particles, fcs_float *positions
   return FCS_RESULT_SUCCESS;
 }
 
-int fcs_mpi_fmm_sort_front_part, fcs_mpi_fmm_sort_back_part, fcs_mpi_fmm_sort_front_merge_presorted;
+extern int fcs_mpi_fmm_sort_front_part, fcs_mpi_fmm_sort_back_part, fcs_mpi_fmm_sort_front_merge_presorted;
 
 /* internal fmm-specific run function */
 FCSResult fcs_fmm_run(FCS handle, fcs_int local_particles,


### PR DESCRIPTION
This pull request fixes #29 and fixes #30

Issue #29 is addressed by adding explicit interfaces to the wrapped MPI calls and thus bypassing the errors (or warnings with the compiler flag workaround) caused by the generation of an implicit interface (which cannot handle using different data types as required by MPI).

Issue #30 is address by declaring one of the two definitions of the same global variables as `extern`.
The compiler flag workaround is not a good solution in this case, since it will hide bugs. If these variables are not meant to be global, they should be declared static instead (also in the other location).

This PR/patch has been tested successfully in LAMMPS (current master) and will be applied manually during the download/compilation process until a new version of ScaFaCoS will be released.